### PR TITLE
Updated the Squidwarc dependency bootstrapping process and bumped node version used by worker image

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:10-slim
 
 # Get key and repo for google chrome stable
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
@@ -13,7 +13,7 @@ RUN apt-get install -y fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fon
 RUN npm install -g npm
 
 # Gigantic list of deps to run chromium headless on debian (see https://github.com/GoogleChrome/puppeteer/issues/290#issuecomment-322838700)
-RUN apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget 
+RUN apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 
 # Install regular Chrome as an alternative - add selection in web frontend later?
 RUN apt-get install google-chrome-stable -y
@@ -31,13 +31,7 @@ WORKDIR /usr/src/app
 # install squidwarc while we have access to python 2.7
 RUN git clone https://github.com/N0taN3rd/Squidwarc.git
 WORKDIR Squidwarc
-
-RUN git checkout puppeteerCrawler 
-RUN git submodule init 
-RUN git submodule update
-RUN npm install
-WORKDIR Squidwarc/node-warc
-RUN npm install
+RUN ./bootstrap.sh
 
 # get python 3.6.6 (build from source)
 ENV LANG C.UTF-8


### PR DESCRIPTION
This PR updates the Squidwarc bootstrapping process used in the workers Docker file to match the changes recently merged into Squidwarc@master.
This PR also bumps the node image version to v10 in order to future proof against Squidwarc updates and to bring in some perf increases.

Future updates to Squidwarc will put additional bootstrapping needs inside `bootstrap.sh` :angel:    
